### PR TITLE
Add the motivation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ derived from machine state) can be very difficult to implement in a _YAML_ forma
 upon this upgrade, such as migrating the existing CRs to the new CRDs
 - **Day-2 Operations**: Taking care of various operations that are considered as Day-2 operations, such as maintaining
 and monitoring the running services and deployments. 
+- **Observability**: Observing and reflecting on the changes in the tinkerbell setup eco-system(e.g: picking up and 
+deploy new configurations without the need of a manual intervention)
+- **Building up the Standards**: Identify and focus on Tinkerbell essential and standard components(e.g: boots and hegel)
+without confusing these components with the utilities(e.g: KubeVip and Nginx), to introduce a more of a clear path of what 
+we support out of the box as a community and what we don't
 
 ## Usage
 Currently, the operator doesn't take care of deploying the needed k8s crds to start the controller, thus, the crds must be 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ the deployment and lifecycle of these Tinkerbell services:
 
 > **_NOTE:_** Kubetink is a tech preview project thus it shouldn't be used in production environments. 
 
+## Motivation
+The Tinkerbell org offers the possibility to install tinkerbell stack using Helm which can be found in this 
+[repo](https://github.com/tinkerbell/charts), which should be the simplest way to install tinkerbell service. However, 
+we have identified different factors which led to start looking into a solution, that introduces more observability and 
+robustness to maintain different complex configurations and manage tinkerbell services lifecycle. 
+
+Here are some of these factors:
+
+- **Complex Configurations**: Different tinkerbell services might need fine-tuned configurations(e.g: configs that are 
+derived from machine state) can be very difficult to implement in a _YAML_ format that Helm offers
+- **Upgrade and Migration**: While it is possible to upgrade tinkerbell services using Helm, it is not possible to react 
+upon this upgrade, such as migrating the existing CRs to the new CRDs
+- **Day-2 Operations**: Taking care of various operations that are considered as Day-2 operations, such as maintaining
+and monitoring the running services and deployments. 
+
 ## Usage
 Currently, the operator doesn't take care of deploying the needed k8s crds to start the controller, thus, the crds must be 
 created first in the k8s cluster, then lunch the operator:

--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@ the deployment and lifecycle of these Tinkerbell services:
 > **_NOTE:_** Kubetink is a tech preview project thus it shouldn't be used in production environments. 
 
 ## Motivation
-The Tinkerbell org offers the possibility to install tinkerbell stack using Helm which can be found in this 
-[repo](https://github.com/tinkerbell/charts), which should be the simplest way to install tinkerbell service. However, 
-we have identified different factors which led to start looking into a solution, that introduces more observability and 
-robustness to maintain different complex configurations and manage tinkerbell services lifecycle. 
+The Tinkerbell organization offers the possibility of installing the Tinkerbell stack using Helm, which can be found in
+this [repository](https://github.com/tinkerbell/charts). This should be the simplest way to install the Tinkerbell service. However, we have identified different 
+factors that have led us to start looking for a solution that introduces more observability and robustness to maintain 
+different complex configurations and manage Tinkerbell service lifecycle.
 
 Here are some of these factors:
 
-- **Complex Configurations**: Different tinkerbell services might need fine-tuned configurations(e.g: configs that are 
-derived from machine state) can be very difficult to implement in a _YAML_ format that Helm offers
-- **Upgrade and Migration**: While it is possible to upgrade tinkerbell services using Helm, it is not possible to react 
-upon this upgrade, such as migrating the existing CRs to the new CRDs
-- **Day-2 Operations**: Taking care of various operations that are considered as Day-2 operations, such as maintaining
-and monitoring the running services and deployments. 
-- **Observability**: Observing and reflecting on the changes in the tinkerbell setup eco-system(e.g: picking up and 
-deploy new configurations without the need of a manual intervention)
-- **Building up the Standards**: Identify and focus on Tinkerbell essential and standard components(e.g: boots and hegel)
-without confusing these components with the utilities(e.g: KubeVip and Nginx), to introduce a more of a clear path of what 
-we support out of the box as a community and what we don't
+- **Complex Configurations**: Different Tinkerbell services might need fine-tuned configurations (e.g., configurations that 
+are derived from machine state). These can be very difficult to implement in a YAML format that Helm offers.
+- **Upgrades and Migration**: While it is possible to upgrade Tinkerbell services using Helm, it is not possible to react to 
+this upgrade, such as migrating the existing CRs to the new CRDs.
+- **Day-2 Operations**: Taking care of various operations that are considered as Day-2 operations, such as maintaining and 
+monitoring the running services and deployments.
+- **Observability**: Observing and reflecting on the changes in the Tinkerbell setup ecosystem (e.g., picking up and deploying 
+new configurations without the need for manual intervention).
+- **Building up the Standards**: Identifying and focusing on Tinkerbell’s essential and standard components (e.g., Boots and Hegel) 
+without confusing these components with utilities (e.g., KubeVip and Nginx) to introduce a clearer path of what we support 
+out of the box as a community and what we do not.
 
 ## Usage
 Currently, the operator doesn't take care of deploying the needed k8s crds to start the controller, thus, the crds must be 


### PR DESCRIPTION
Include a new section in the _README.md_ file, which support the claims of why we need a Kubernetes operator to deploy Tinkerbell stack, and why using helm charts might not be enough.  